### PR TITLE
feat(config): Implement fileWatcher.enable user configuration to auto-enable fileWatcher via workspace settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is currently disabled by default, the behaviour is - It will push all files
 
 You can change the directory being watching with the `bitburner.scriptRoot` settng within the plugin configuration, open VSCode preferences to modify the value - default as `./` (workspace root).
 
-You can enable the fileWatcher by default with the `bitburner.fileWatcher.enable` setting within the plugin configuration. If you have this extension enabled globally **DO NOT** enable this option in user settings (workspace and folder only), it may try to push unintended files to bitburner if the filepath matches.
+You can enable the fileWatcher by default with the `bitburner.fileWatcher.enable` setting within the plugin configuration. This setting will not work if set in user settings, it must be set at the workspace or folder level.
 
 **NOTE: You can only watch paths within the workspace VSCode has open.**
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This is currently disabled by default, the behaviour is - It will push all files
 
 You can change the directory being watching with the `bitburner.scriptRoot` settng within the plugin configuration, open VSCode preferences to modify the value - default as `./` (workspace root).
 
+You can enable the fileWatcher by default with the `bitburner.fileWatcher.enable` setting within the plugin configuration. If you have this extension enabled globally **DO NOT** enable this option in user settings (workspace and folder only), it may try to push unintended files to bitburner if the filepath matches.
+
 **NOTE: You can only watch paths within the workspace VSCode has open.**
 
 ### Behaviour

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
           "bitburner.fileWatcher.enable": {
             "type": "boolean",
             "default": false,
-            "description": "Enable the file watcher (May cause unexpected files to be pushed to bitburner if this is enabled globally, enable only in workspace and folder settings)"
+            "description": "Enable the file watcher by default. (This setting will not work if set in global (user) settings, it must be set at the workspace or folder level)"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
           "bitburner.fileWatcher.enable": {
             "type": "boolean",
             "default": false,
-            "description": "Enable the file watcher (disabled by default)"
+            "description": "Enable the file watcher (May cause unexpected files to be pushed to bitburner if this is enabled globally, enable only in workspace and folder settings)"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
             "type": "string",
             "default": "./",
             "description": "The root directory of the scripts you want to push to the game. (Use with the File Watcher)"
+          },
+          "bitburner.fileWatcher.enable": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable the file watcher (disabled by default)"
           }
         }
       }

--- a/src/extension.js
+++ b/src/extension.js
@@ -16,7 +16,7 @@ const BB_GAME_CONFIG = {
  * @type vscode.FileSystemWatcher
  */
 let fsWatcher;
-let fwEnabled = false;
+let fwEnabled;
 
 let sanitizedUserConfig;
 
@@ -30,6 +30,10 @@ function activate(context) {
   const disposableCommands = [];
 
   sanitizeUserConfig();
+
+  if(fwEnabled) {
+    initFileWatcher(sanitizedUserConfig.scriptRoot);
+  }
 
   const configChangeListener = vscode.workspace.onDidChangeConfiguration(() => {
     sanitizeUserConfig();
@@ -244,9 +248,17 @@ module.exports = {
 const sanitizeUserConfig = () => {
   const userConfig = vscode.workspace.getConfiguration(`bitburner`);
 
+  // Checks if initializing or user config changed for fileWatcher.enabled
+  if(sanitizedUserConfig === undefined || 
+     sanitizedUserConfig.fwEnabled !== userConfig.get(`fileWatcher.enable`)) {
+      fwEnabled = userConfig.get(`fileWatcher.enable`)
+  }
+
   sanitizedUserConfig = {
     scriptRoot: `${userConfig.get(`scriptRoot`)}/`
       .replace(/^\./, ``)
       .replace(/\/*$/, `/`),
+    fwEnabled: userConfig.get(`fileWatcher.enable`)
   };
 };
+

--- a/src/extension.js
+++ b/src/extension.js
@@ -247,18 +247,26 @@ module.exports = {
 
 const sanitizeUserConfig = () => {
   const userConfig = vscode.workspace.getConfiguration(`bitburner`);
+  const fwInspect = vscode.workspace.getConfiguration('bitburner').inspect('fileWatcher.enable');
+  const fwVal = fwInspect.workspaceValue || fwInspect.workspaceFolderValue || fwInspect.defaultValue; // Only accepts values from workspace or folder level configs
+
+  if(fwInspect.globalValue) {
+    vscode.window.showErrorMessage(
+      `Warning: You have enabled the bitburner filewatcher in your global (user) settings, the extension will default to workspace or folder settings instead.`
+    );
+  }
 
   // Checks if initializing or user config changed for fileWatcher.enabled
   if(sanitizedUserConfig === undefined || 
-     sanitizedUserConfig.fwEnabled !== userConfig.get(`fileWatcher.enable`)) {
-      fwEnabled = userConfig.get(`fileWatcher.enable`)
+     sanitizedUserConfig.fwEnabled !== fwVal) {
+      fwEnabled = fwVal;
   }
 
   sanitizedUserConfig = {
     scriptRoot: `${userConfig.get(`scriptRoot`)}/`
       .replace(/^\./, ``)
       .replace(/\/*$/, `/`),
-    fwEnabled: userConfig.get(`fileWatcher.enable`)
+    fwEnabled: fwVal
   };
 };
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -269,4 +269,3 @@ const sanitizeUserConfig = () => {
     fwEnabled: fwVal
   };
 };
-


### PR DESCRIPTION
Does not accept values from the global configuration, only folder or workspace.

Sends an error message informing the user that the folder or workspace settings will be used instead.